### PR TITLE
Add version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ curl https://flux-capacitor/install.sh | sh
 ```
 
 ## Commands
- 
- - project create 
+
+ - project create
+ - version
 
 See the `--help` for more information.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.gradle.jvm.tasks.Jar
 
 plugins {
     application
@@ -35,6 +36,14 @@ application {
 
 tasks.shadowJar {
     mergeServiceFiles()
+}
+
+tasks.withType<Jar>().configureEach {
+    manifest {
+        attributes(
+            "Implementation-Version" to project.version,
+        )
+    }
 }
 
 sourceSets {

--- a/src/main/kotlin/host/flux/cli/Main.kt
+++ b/src/main/kotlin/host/flux/cli/Main.kt
@@ -21,5 +21,8 @@ class FluxCli : CliktCommand() {
 
 
 fun main(args: Array<String>) = FluxCli()
-    .subcommands(Init())
+    .subcommands(
+        Init(),
+        Version(),
+    )
     .main(args)

--- a/src/main/kotlin/host/flux/cli/Version.kt
+++ b/src/main/kotlin/host/flux/cli/Version.kt
@@ -1,0 +1,16 @@
+package host.flux.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+
+class Version(private val versionProvider: () -> String = { defaultVersion() }) : CliktCommand(help = "Print the release version of the flux-cli") {
+    override fun run() {
+        echo(versionProvider())
+    }
+
+    companion object {
+        private fun defaultVersion(): String {
+            // Implementation-Version is set by the build system when the jar is assembled
+            return Version::class.java.`package`.implementationVersion ?: "dev"
+        }
+    }
+}

--- a/src/test/kotlin/host/flux/cli/commands/VersionTest.kt
+++ b/src/test/kotlin/host/flux/cli/commands/VersionTest.kt
@@ -1,0 +1,15 @@
+package host.flux.cli.commands
+
+import com.github.ajalt.clikt.testing.test
+import host.flux.cli.Version
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VersionTest {
+    @Test
+    fun `prints provided version`() {
+        val cmd = Version(versionProvider = { "1.2.3" })
+        val result = cmd.test(emptyList())
+        assertEquals("1.2.3\n", result.stdout)
+    }
+}


### PR DESCRIPTION
## Summary
- implement `version` command
- wire the command into the CLI
- document `version` in README
- test `version` command
- ensure jar manifest contains `Implementation-Version`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684149dee1a88323a42b917cb166e357