### PR TITLE
Add version update check on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ Features
 - replace package names ""
 - remove files 
 - remove certain lines 
+
+## Building the CLI
+
+```shell
+./gradlew build shadowJar
+java -jar build/libs/flux-cli-1.0.0-all.jar version
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "host.flux.cli"
-version = (project.properties["appVersion"] ?: "1.0.0") as String
+version = (project.properties["appVersion"] ?: "dev") as String
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/host/flux/cli/Main.kt
+++ b/src/main/kotlin/host/flux/cli/Main.kt
@@ -7,6 +7,11 @@ import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.sources.PropertiesValueSource
 import host.flux.cli.commands.Init
 import host.flux.cli.commands.Version
+import host.flux.cli.UpdateChecker
+
+/**
+ * Checks for updates on startup and then launches the CLI.
+ */
 
 class FluxCli : CliktCommand() {
     init {
@@ -22,9 +27,13 @@ class FluxCli : CliktCommand() {
 }
 
 
-fun main(args: Array<String>) = FluxCli()
-    .subcommands(
-        Init(),
-        Version(),
-    )
-    .main(args)
+fun main(args: Array<String>) {
+    val currentVersion = Version::class.java.`package`.implementationVersion ?: "dev"
+    UpdateChecker.notifyIfNewVersion(currentVersion) { println(it) }
+    FluxCli()
+        .subcommands(
+            Init(),
+            Version(),
+        )
+        .main(args)
+}

--- a/src/main/kotlin/host/flux/cli/UpdateChecker.kt
+++ b/src/main/kotlin/host/flux/cli/UpdateChecker.kt
@@ -8,6 +8,22 @@ import java.net.http.HttpResponse
 object UpdateChecker {
     private const val LATEST_RELEASE_URL = "https://api.github.com/repos/flux-capacitor-io/flux-cli/releases/latest"
 
+    internal fun isNewer(current: String, latest: String): Boolean {
+        val curParts = parseVersion(current)
+        val latestParts = parseVersion(latest)
+        val max = maxOf(curParts.size, latestParts.size)
+        for (i in 0 until max) {
+            val c = curParts.getOrNull(i) ?: 0
+            val l = latestParts.getOrNull(i) ?: 0
+            if (l > c) return true
+            if (l < c) return false
+        }
+        return false
+    }
+
+    private fun parseVersion(v: String): List<Int> =
+        v.removePrefix("v").split("[.-]".toRegex()).mapNotNull { it.toIntOrNull() }
+
     fun notifyIfNewVersion(currentVersion: String, notify: (String) -> Unit = ::println) {
         try {
             val request = HttpRequest.newBuilder()
@@ -18,7 +34,7 @@ object UpdateChecker {
             if (response.statusCode() == 200) {
                 val tagRegex = "\"tag_name\"\\s*:\\s*\"([^\"]+)\"".toRegex()
                 val latest = tagRegex.find(response.body())?.groupValues?.get(1)
-                if (latest != null && latest != currentVersion) {
+                if (latest != null && isNewer(currentVersion, latest)) {
                     notify("A new version of flux-cli is available: $latest (current: $currentVersion)")
                 }
             }

--- a/src/main/kotlin/host/flux/cli/UpdateChecker.kt
+++ b/src/main/kotlin/host/flux/cli/UpdateChecker.kt
@@ -1,0 +1,30 @@
+package host.flux.cli
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+object UpdateChecker {
+    private const val LATEST_RELEASE_URL = "https://api.github.com/repos/flux-capacitor-io/flux-cli/releases/latest"
+
+    fun notifyIfNewVersion(currentVersion: String, notify: (String) -> Unit = ::println) {
+        try {
+            val request = HttpRequest.newBuilder()
+                .uri(URI.create(LATEST_RELEASE_URL))
+                .header("Accept", "application/json")
+                .build()
+            val response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
+            if (response.statusCode() == 200) {
+                val tagRegex = "\"tag_name\"\\s*:\\s*\"([^\"]+)\"".toRegex()
+                val latest = tagRegex.find(response.body())?.groupValues?.get(1)
+                if (latest != null && latest != currentVersion) {
+                    notify("A new version of flux-cli is available: $latest (current: $currentVersion)")
+                }
+            }
+        } catch (_: Exception) {
+            // Fail silently if update check fails
+        }
+    }
+}
+

--- a/src/test/kotlin/host/flux/cli/UpdateCheckerTest.kt
+++ b/src/test/kotlin/host/flux/cli/UpdateCheckerTest.kt
@@ -1,0 +1,19 @@
+import host.flux.cli.UpdateChecker
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UpdateCheckerTest {
+    @Test
+    fun `isNewer returns true for newer version`() {
+        assertTrue(UpdateChecker.isNewer("1.0.0", "1.0.1"))
+        assertTrue(UpdateChecker.isNewer("1.0.0", "2.0.0"))
+        assertTrue(UpdateChecker.isNewer("1.2.3", "1.3.0"))
+    }
+
+    @Test
+    fun `isNewer returns false when not newer`() {
+        assertFalse(UpdateChecker.isNewer("1.0.0", "1.0.0"))
+        assertFalse(UpdateChecker.isNewer("1.0.0", "0.9.9"))
+    }
+}


### PR DESCRIPTION
## Summary
- notify user if a newer release of `flux-cli` is available
- check GitHub releases before launching commands

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6842a3e5d9b48323976ea7bb9443a271